### PR TITLE
feat: allow gateway to name itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "netlink-packet-wireguard",
  "netlink-sys",
  "prost",
+ "prost-build",
  "serde",
  "syslog",
  "thiserror",
@@ -1307,14 +1308,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -1336,6 +1337,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -1664,13 +1675,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -1734,14 +1744,14 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.2",
  "bytes",
  "flate2",
  "futures-core",
@@ -1754,25 +1764,22 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1855,16 +1862,6 @@ checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -2034,16 +2031,6 @@ checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted 0.7.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 prost = "0.11"
 syslog = "6.0"
 thiserror = "1.0"
-tonic = {version = "0.8", features = ["gzip", "tls", "tls-roots"] }
+tonic = {version = "0.9", features = ["gzip", "tls", "tls-roots"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = [] }
 toml = "0.7.3"
@@ -27,7 +27,8 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["io-std", "io-util"] }
 
 [build-dependencies]
-tonic-build = { version = "0.8" }
+tonic-build = { version = "0.9" }
+prost-build = { version = "0.11" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netlink-packet-core = "0.5"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // compiling protos using path on build time
-    tonic_build::compile_protos("proto/wireguard/gateway.proto")?;
+    let mut config = prost_build::Config::new();
+    config.protoc_arg("--experimental_allow_proto3_optional");
+    tonic_build::configure().compile_with_config(
+        config,
+        &["proto/wireguard/gateway.proto"],
+        &["proto/wireguard"],
+    )?;
     Ok(())
 }

--- a/example-config.toml
+++ b/example-config.toml
@@ -7,6 +7,8 @@ token = "<your_gateway_token>"
 # Required: Defguard server gRPC endpoint URL
 # NOTE: must replace default with actual value
 grpc_url = "<defguard_grpc_url>"
+# Optional: gateway name which will be displayed in Defguard web UI
+name = "Gateway A"
 # Required: use userspace Wireguard implementation (e.g. wireguard-go)
 userspace = false
 # Optional: path to TLS cert file

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,3 +1,4 @@
+use defguard_gateway::proto::ConfigurationRequest;
 use defguard_gateway::{
     proto,
     wireguard::{Host, IpAddrMask, Key, Peer},
@@ -81,7 +82,10 @@ impl From<&HostConfig> for proto::Configuration {
 impl proto::gateway_service_server::GatewayService for GatewayServer {
     type UpdatesStream = UnboundedReceiverStream<Result<proto::Update, Status>>;
 
-    async fn config(&self, request: Request<()>) -> Result<Response<proto::Configuration>, Status> {
+    async fn config(
+        &self,
+        request: Request<ConfigurationRequest>,
+    ) -> Result<Response<proto::Configuration>, Status> {
         let address = request.remote_addr().unwrap();
         eprintln!("CONFIG connected from: {}", address);
         Ok(Response::new((&*self.config_rx.borrow()).into()))

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use toml;
 #[clap(about = "Defguard VPN gateway service")]
 #[command(version)]
 pub struct Config {
-    #[clap(
+    #[arg(
         long,
         short = 't',
         required_unless_present = "config_path",
@@ -18,7 +18,10 @@ pub struct Config {
     )]
     pub token: String,
 
-    #[clap(
+    #[arg(long, env = "DEFGUARD_GATEWAY_NAME")]
+    pub name: Option<String>,
+
+    #[arg(
         long,
         short = 'g',
         required_unless_present = "config_path",
@@ -28,7 +31,7 @@ pub struct Config {
     )]
     pub grpc_url: String,
 
-    #[clap(
+    #[arg(
         long,
         short = 'u',
         env = "DEFGUARD_USERSPACE",
@@ -36,10 +39,10 @@ pub struct Config {
     )]
     pub userspace: bool,
 
-    #[clap(long, env = "DEFGUARD_GRPC_CA")]
+    #[arg(long, env = "DEFGUARD_GRPC_CA")]
     pub grpc_ca: Option<String>,
 
-    #[clap(
+    #[arg(
         long,
         short = 'p',
         env = "DEFGUARD_STATS_PERIOD",
@@ -48,7 +51,7 @@ pub struct Config {
     )]
     pub stats_period: u64,
 
-    #[clap(
+    #[arg(
         long,
         short = 'i',
         env = "DEFGUARD_IFNAME",
@@ -57,19 +60,19 @@ pub struct Config {
     )]
     pub ifname: String,
 
-    #[clap(long, help = "Write pid to this file")]
+    #[arg(long, help = "Write pid to this file")]
     pub pidfile: Option<String>,
 
-    #[clap(long, short = 's', help = "Log to syslog")]
+    #[arg(long, short = 's', help = "Log to syslog")]
     pub use_syslog: bool,
 
-    #[clap(long, default_value = "LOG_USER", help = "Log to syslog")]
+    #[arg(long, default_value = "LOG_USER", help = "Log to syslog")]
     pub syslog_facility: String,
 
-    #[clap(long, default_value = "/var/run/log", help = "Log to syslog")]
+    #[arg(long, default_value = "/var/run/log", help = "Log to syslog")]
     pub syslog_socket: String,
 
-    #[clap(long = "config", short, help = "Config file")]
+    #[arg(long = "config", short, help = "Config file")]
     #[serde(skip)]
     config_path: Option<std::path::PathBuf>,
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,4 +1,5 @@
 use crate::mask;
+use crate::proto::ConfigurationRequest;
 #[cfg(target_os = "linux")]
 use crate::wireguard::netlink::delete_interface;
 use crate::{
@@ -109,7 +110,11 @@ async fn connect(
         debug!("Connecting to Defguard GRPC endpoint: {}", config.grpc_url);
         let (response, stream) = {
             let mut client = client.lock().await;
-            let response = client.config(Request::new(())).await;
+            let response = client
+                .config(ConfigurationRequest {
+                    name: config.name.clone(),
+                })
+                .await;
             let stream = client.updates(()).await;
             (response, stream)
         };


### PR DESCRIPTION
Add a `--name` CLI option (along with a related env variable) which allows the user to give a specific gateway a name which will be displayed in Defguard webapp.