### PR TITLE
Add explicit missing CA file error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.idea
 .envrc
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,43 +1,6 @@
 {
   "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1728018373,
-        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
+    "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
@@ -52,6 +15,64 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731139594,
+        "narHash": "sha256-IigrKK3vYRpUu+HEjPL/phrfh7Ox881er1UEsZvw9Q4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "76612b17c0ce71689921ca12d9ffdc9c23ce40b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731464916,
+        "narHash": "sha256-WZ5rpjr/wCt7yBOUsvDE2i22hYz9g8W921jlwVktRQ4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2c19bad6e881b5a154cafb7f9106879b5b356d1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,30 @@
   description = "Rust development flake";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-    utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
   };
 
-  outputs = { nixpkgs, utils, ... }:
-    utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs {inherit system;};
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      overlays = [(import rust-overlay)];
+      pkgs = import nixpkgs {
+        inherit system overlays;
+      };
+      rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+        extensions = ["rust-analyzer" "rust-src" "rustfmt" "clippy"];
+      };
     in {
       devShells.default = pkgs.mkShell {
         packages = with pkgs; [
@@ -16,10 +33,7 @@
           openssl
           protobuf
           sqlx-cli
-          cargo
-          rustc
-          rust-analyzer
-          clippy
+          rustToolchain
         ];
       };
     });

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, path::PathBuf};
 
 use clap::Parser;
 use serde::Deserialize;
@@ -37,8 +37,9 @@ pub struct Config {
     #[arg(long, short = 'u', env = "DEFGUARD_USERSPACE")]
     pub userspace: bool,
 
+    /// Path to CA file
     #[arg(long, env = "DEFGUARD_GRPC_CA")]
-    pub grpc_ca: Option<String>,
+    pub grpc_ca: Option<PathBuf>,
 
     /// Defines how often (in seconds) interface statistics are sent to Defguard server
     #[arg(long, short = 'p', env = "DEFGUARD_STATS_PERIOD", default_value = "30")]
@@ -50,7 +51,7 @@ pub struct Config {
 
     /// Write process ID (PID) to this file
     #[arg(long)]
-    pub pidfile: Option<String>,
+    pub pidfile: Option<PathBuf>,
 
     /// Log to syslog
     #[arg(long, short = 's')]
@@ -62,12 +63,12 @@ pub struct Config {
 
     /// Syslog socket path
     #[arg(long, default_value = "/var/run/log")]
-    pub syslog_socket: String,
+    pub syslog_socket: PathBuf,
 
     /// Configuration file path
     #[arg(long = "config", short)]
     #[serde(skip)]
-    config_path: Option<std::path::PathBuf>,
+    config_path: Option<PathBuf>,
 
     /// Command to run before bringing up the interface.
     #[arg(long, env = "PRE_UP")]
@@ -104,7 +105,7 @@ impl Default for Config {
             pidfile: None,
             use_syslog: false,
             syslog_facility: String::new(),
-            syslog_socket: String::new(),
+            syslog_socket: PathBuf::new(),
             config_path: None,
             pre_up: None,
             post_up: None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,11 +3,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum GatewayError {
-    #[error("Command execution failed")]
-    CommandExecutionFailed(#[from] std::io::Error),
-
-    #[error("Command returned error status `{stderr}`")]
-    CommandExecutionError { stderr: String },
+    #[error("Command {command} execution failed. Error: {error}")]
+    CommandExecutionFailed { command: String, error: String },
 
     #[error("WireGuard key error")]
     KeyDecode(#[from] base64::DecodeError),
@@ -35,4 +32,10 @@ pub enum GatewayError {
 
     #[error("HTTP error")]
     HttpServer(String),
+
+    #[error("Invalid CA file. Error")]
+    InvalidCaFile,
+
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -338,7 +338,10 @@ impl Gateway {
         debug!("Preparing gRPC client configuration");
         // Use CA if provided, otherwise load certificates from system.
         let tls = if let Some(ca) = &config.grpc_ca {
-            let ca = read_to_string(ca)?;
+            let ca = read_to_string(ca).map_err(|err| {
+                error!("Failed to read CA file: {err}");
+                GatewayError::InvalidCaFile
+            })?;
             ClientTlsConfig::new().ca_certificate(Certificate::from_pem(ca))
         } else {
             ClientTlsConfig::new().with_native_roots()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub fn execute_command(command: &str) -> Result<(), GatewayError> {
             let stderr = String::from_utf8_lossy(&output.stderr);
 
             info!(
-                "Postup command {} executed successfully. Stdout: {}",
+                "Command {} executed successfully. Stdout: {}",
                 command, stdout
             );
             if !stderr.is_empty() {
@@ -73,7 +73,7 @@ pub fn execute_command(command: &str) -> Result<(), GatewayError> {
             }
         } else {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            error!("Error executing command. Stderr:\n{stderr}");
+            error!("Error executing command {command}. Stderr:\n{stderr}");
         }
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,14 @@ pub fn execute_command(command: &str) -> Result<(), GatewayError> {
     if let Some(command) = command_parts.next() {
         let output = process::Command::new(command)
             .args(command_parts)
-            .output()?;
+            .output()
+            .map_err(|err| {
+                error!("Failed to execute command {command}. Error: {err}");
+                GatewayError::CommandExecutionFailed {
+                    command: command.to_string(),
+                    error: err.to_string(),
+                }
+            })?;
 
         if output.status.success() {
             let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
Make it clear when reading specified CA file fails.
Avoid blanket conversion of all std::io errors and add a dedicated error variant for command execution failure.