### PR TITLE
add option to disable firewall mgmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - 'release/**'
     paths-ignore:
       - "*.md"
       - "LICENSE"
@@ -12,6 +13,7 @@ on:
     branches:
       - main
       - dev
+      - 'release/**'
     paths-ignore:
       - "*.md"
       - "LICENSE"

--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - dev
+      - 'release/**'
     paths-ignore:
       - "*.md"
       - "LICENSE"
@@ -17,6 +18,5 @@ jobs:
     uses: ./.github/workflows/build-docker.yml
     with:
       tags: |
-        type=raw,value=current
         type=ref,event=branch
         type=sha

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,6 +99,12 @@ pub struct Config {
     #[arg(long, env = "DEFGUARD_FW_PRIORITY")]
     #[serde(default)]
     pub fw_priority: Option<i32>,
+
+    /// Whether all firewall management should be disabled
+    /// Meant to be used as a workaround for incompatible hardware
+    #[arg(long, env = "DEFGUARD_DISABLE_FW_MGMT")]
+    #[serde(default)]
+    pub disable_firewall_management: bool,
 }
 
 impl Default for Config {
@@ -123,6 +129,7 @@ impl Default for Config {
             health_port: None,
             masquerade: false,
             fw_priority: None,
+            disable_firewall_management: false,
         }
     }
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -595,7 +595,7 @@ impl Gateway {
             );
         } else {
             #[cfg(target_os = "linux")]
-            if self.config.masquerade {
+            if !self.config.disable_firewall_management && self.config.masquerade {
                 self.firewall_api.begin()?;
                 self.firewall_api.set_masquerade_status(true)?;
                 self.firewall_api.commit()?;

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -382,14 +382,19 @@ impl Gateway {
             debug!("Received configuration is identical to the current one. Skipping interface reconfiguration.");
         }
 
-        let new_firewall_configuration =
-            if let Some(firewall_config) = new_configuration.firewall_config {
-                Some(FirewallConfig::from_proto(firewall_config)?)
-            } else {
-                None
-            };
+        // process received firewall config unless firewall management is disabled
+        if !self.config.disable_firewall_management {
+            let new_firewall_configuration =
+                if let Some(firewall_config) = new_configuration.firewall_config {
+                    Some(FirewallConfig::from_proto(firewall_config)?)
+                } else {
+                    None
+                };
 
-        self.process_firewall_changes(new_firewall_configuration.as_ref())?;
+            self.process_firewall_changes(new_firewall_configuration.as_ref())?;
+        } else {
+            debug!("Firewall management is disabled. Skipping updating firewall configuration");
+        }
 
         Ok(())
     }
@@ -512,6 +517,11 @@ impl Gateway {
                             };
                         }
                         Some(update::Update::FirewallConfig(config)) => {
+                            if self.config.disable_firewall_management {
+                                debug!("Received firewall config update, but firewall management is disabled. Skipping processing this update: {config:?}");
+                                continue;
+                            }
+
                             debug!("Applying received firewall configuration: {config:?}");
                             let config_str = format!("{config:?}");
                             match FirewallConfig::from_proto(config) {
@@ -539,6 +549,11 @@ impl Gateway {
                             }
                         }
                         Some(update::Update::DisableFirewall(())) => {
+                            if self.config.disable_firewall_management {
+                                debug!("Received firewall disable request, but firewall management is disabled. Skipping processing this update");
+                                continue;
+                            }
+
                             debug!("Disabling firewall configuration");
                             if let Err(err) = self.process_firewall_changes(None) {
                                 error!("Failed to disable firewall configuration: {err}");


### PR DESCRIPTION
Add option to disable all firewall management.
Meant as a workaround for incompatible hardware. 

Closes https://github.com/DefGuard/gateway/issues/170