### PR TITLE
Migrate docker builds to AWS

### DIFF
--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -5,7 +5,6 @@ on:
       - main
       - dev
       - 'release/**'
-      - aws_docker_build
     paths-ignore:
       - "*.md"
       - "LICENSE"


### PR DESCRIPTION
Leverage our CodeBuild runners for quicker docker builds.

Resolves https://github.com/DefGuard/defguard/issues/1565