### PR TITLE
Disable latest Docker tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,17 @@ concurrency:
 jobs:
   build-docker-release:
     # Ignore tags with -, like v1.0.0-alpha
-    # This job will build the docker container with the "latest" tag which
-    # is a tag used in production, thus it should only be run for full releases.
     if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-')
     name: Build Release Docker image
     uses: ./.github/workflows/build-docker.yml
     with:
       tags: |
-        type=raw,value=latest
         type=semver,pattern={{version}}
         type=semver,pattern={{major}}.{{minor}}
         type=sha
+      # Explicitly disable latest tag. It will be added otherwise.
+      flavor: |
+        latest=false
 
   build-docker-prerelease:
     # Only build tags with -, like v1.0.0-alpha


### PR DESCRIPTION
Don't automatically tag Docker images as `latest`.

Related https://github.com/DefGuard/internal/issues/35