### PR TITLE
Defguard Gateway service not registered on opnsense in 1.6.3

### DIFF
--- a/opnsense/src/etc/inc/plugins.inc.d/defguardgateway.inc
+++ b/opnsense/src/etc/inc/plugins.inc.d/defguardgateway.inc
@@ -7,7 +7,7 @@ function defguardgateway_services()
 
     $pidfile = (string) (new OPNsense\DefguardGateway\DefguardGateway())->general->PidFile;
 
-    if (isset($config['OPNsense']['defguardgateway']['general']['enabled']) && $config['OPNsense']['defguardgateway']['general']['enabled'] == 1) {
+    if (isset($config['OPNsense']['defguardgateway']['general']['Enabled']) && $config['OPNsense']['defguardgateway']['general']['Enabled'] == 1) {
         $services[] = [
             "description" => "Defguard Gateway",
             "configd" => [


### PR DESCRIPTION
## 📖 Description

In 1.6.3 the Defguard Gateway service is not being registered. This is because of a mismatch between the field name and case. OPNsense's MVC framework stores XML model field names exactly as defined. The model defines <Enabled> with a capital E, and that's how it appears in the $config array at runtime.

In our config, half the cases look for 'enabled' and the other half look for 'Enabled'. Making it consistent.

### 🛠️ Dev Branch Merge Checklist:

#### Documentation ###

- [NA] If testing requires changes in the environment or deployment, please **update the documentation** (https://defguard.gitbook.io) first and **attach the link to the documentation** section in this pool request
- [NA] I have commented on my code, particularly in hard-to-understand areas

#### Testing ### 

- [NA] I have prepared end-to-end tests for all new functionalities
- [x] I have performed end-to-end tests manually and they work
- [x] New and existing unit tests pass locally with my changes

#### Deployment ###

- [NA] If deployment is affected I have made corresponding/required changes to [deployment](https://github.com/defguard/deployment) (Docker, Kubernetes, one-line install)

### 🏚️ Main Branch Merge Checklist:

#### Testing ### 

- [NA] I have merged my changes before to dev and the dev checklist is done
- [NA] I have tested all functionalities on the dev instance and they work

#### Documentation ###

- [NA] I have made corresponding changes to the **user & admin documentation** and added new features documentation with screenshots for users/admins
