### PR TITLE
Add docker tagging workflow

### DIFF
--- a/.github/workflows/publish-docker-latest.yml
+++ b/.github/workflows/publish-docker-latest.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.0
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Login to GitHub container registry
         uses: docker/login-action@v4

--- a/.github/workflows/publish-docker-latest.yml
+++ b/.github/workflows/publish-docker-latest.yml
@@ -1,0 +1,54 @@
+name: Publish Docker latest tag
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  tag-docker-latest:
+    # Only run when the release is marked as "Latest release" in the GitHub UI
+    if: github.event.release.make_latest == 'true'
+    runs-on: [self-hosted, Linux]
+
+    env:
+      GHCR_REPO: ghcr.io/defguard/gateway
+
+    permissions:
+      packages: write
+      id-token: write # needed for Cosign keyless signing
+
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.0
+
+      - name: Login to GitHub container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Derive semver tag
+        run: |
+          # Strip the leading 'v' from the release tag name (e.g. v1.2.3 -> 1.2.3)
+          VERSION="${{ github.event.release.tag_name }}"
+          echo "VERSION=${VERSION#v}" >> $GITHUB_ENV
+
+      - name: Tag image as latest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.GHCR_REPO }}:latest \
+            ${{ env.GHCR_REPO }}:${{ env.VERSION }}
+
+      - name: Sign the latest tag with GitHub OIDC Token
+        run: cosign sign --yes ${{ env.GHCR_REPO }}:latest
+
+      - name: Verify image signature
+        run: |
+          cosign verify ${{ env.GHCR_REPO }}:latest \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp="https://github.com/DefGuard/gateway" \
+            -o text

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,17 @@ concurrency:
 jobs:
   build-docker-release:
     # Ignore tags with -, like v1.0.0-alpha
-    # This job will build the docker container with the "latest" tag which
-    # is a tag used in production, thus it should only be run for full releases.
     if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-')
     name: Build Release Docker image
     uses: ./.github/workflows/build-docker.yml
     with:
       tags: |
-        type=raw,value=latest
         type=semver,pattern={{version}}
         type=semver,pattern={{major}}.{{minor}}
         type=sha
+      # Explicitly disable latest tag. It will be added by publish-docker-latest.yml.
+      flavor: |
+        latest=false
 
   build-docker-prerelease:
     # Only build tags with -, like v1.0.0-alpha


### PR DESCRIPTION
Tag docker image as latest only if the release itself is marked as latest.

Related to https://github.com/DefGuard/internal/issues/35