### PR TITLE
update trivyignore for unpatched CVEs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -75,6 +75,9 @@ jobs:
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@0.35.0
+        env:
+          TRIVY_SHOW_SUPPRESSED: 1
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
         with:
           image-ref: "${{ env.GHCR_REPO }}:${{ github.sha }}-${{ matrix.tag }}"
           format: "table"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -74,7 +74,7 @@ jobs:
           cache-to: type=registry,mode=max,ref=${{ env.GHCR_REPO }}:cache-${{ matrix.tag }}-${{ env.SAFE_REF }}
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         env:
           TRIVY_SHOW_SUPPRESSED: 1
           TRIVY_IGNOREFILE: "./.trivyignore.yaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,10 @@ jobs:
           submodules: recursive
 
       - name: Scan code with Trivy
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_SHOW_SUPPRESSED: 1
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -33,7 +33,10 @@ jobs:
           submodules: recursive
 
       - name: Create SBOM with Trivy
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_SHOW_SUPPRESSED: 1
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
         with:
           scan-type: 'fs'
           format: 'spdx-json'
@@ -43,7 +46,10 @@ jobs:
           scanners: "vuln"
 
       - name: Create docker image SBOM with Trivy
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_SHOW_SUPPRESSED: 1
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
         with:
           image-ref: "ghcr.io/defguard/gateway:${{ steps.vars.outputs.VERSION }}"
           scan-type: 'image'
@@ -53,7 +59,10 @@ jobs:
           scanners: "vuln"
 
       - name: Create security advisory file with Trivy
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_SHOW_SUPPRESSED: 1
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
         with:
           scan-type: 'fs'
           format: 'json'
@@ -63,7 +72,10 @@ jobs:
           scanners: "vuln"
 
       - name: Create Docker image security advisory file with Trivy
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_SHOW_SUPPRESSED: 1
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
         with:
           image-ref: "ghcr.io/defguard/gateway:${{ steps.vars.outputs.VERSION }}"
           scan-type: 'image'

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,10 @@
+vulnerabilities:
+  - id: CVE-2026-29111
+    expired_at: 2026-05-31
+    statement: "No fixed version available in debian:13-slim - waiting for Debian to backport systemd patch"
+  - id: CVE-2025-69720
+    expired_at: 2026-05-31
+    statement: "No fixed version available in debian:13-slim - waiting for Debian to release ncurses patch"
+  - id: CVE-2026-35535
+    expired_at: 2026-05-31
+    statement: "No fixed version available in debian:13-slim - waiting for Debian to release sudo patch"


### PR DESCRIPTION
Add entries for vulnerabilities which are unpatched in the upstream Debian image with no fixed version available yet.